### PR TITLE
Add todo insert_inputs_seen dummy test utils method

### DIFF
--- a/lianad/src/testutils.rs
+++ b/lianad/src/testutils.rs
@@ -728,6 +728,10 @@ impl DatabaseConnection for DummyDatabase {
     ) -> Option<SessionId> {
         todo!()
     }
+
+    fn insert_input_seen_before(&mut self, _outpoints: &[bitcoin::OutPoint]) -> bool {
+        todo!()
+    }
 }
 
 pub struct DummyLiana {


### PR DESCRIPTION
This missing method in the dummy test utils was again causing some more clippy faliures.